### PR TITLE
feat: LCP event has a source and target

### DIFF
--- a/src/bundler/BundleGroup.js
+++ b/src/bundler/BundleGroup.js
@@ -78,7 +78,6 @@ export const getEventProperties = (event, bundle) => {
         timeDelta,
         source: event.source ?? undefined,
         target: event.target ?? undefined,
-        test: 'Alex testing...',
       });
     }
     return { checkpoint: 'cwv', timeDelta };

--- a/src/bundler/BundleGroup.js
+++ b/src/bundler/BundleGroup.js
@@ -78,6 +78,7 @@ export const getEventProperties = (event, bundle) => {
         timeDelta,
         source: event.source ?? undefined,
         target: event.target ?? undefined,
+        test: 'Alex testing...',
       });
     }
     return { checkpoint: 'cwv', timeDelta };

--- a/src/bundler/BundleGroup.js
+++ b/src/bundler/BundleGroup.js
@@ -72,11 +72,13 @@ export const getEventProperties = (event, bundle) => {
     const type = getCWVEventType(event);
     if (type) {
       // @ts-ignore
-      return {
+      return pruneUndefined({
         checkpoint: `cwv-${type.toLowerCase()}`,
         value: event[type],
         timeDelta,
-      };
+        source: event.source ?? undefined,
+        target: event.target ?? undefined,
+      });
     }
     return { checkpoint: 'cwv', timeDelta };
   }

--- a/test/bundler/BundleGroup.test.js
+++ b/test/bundler/BundleGroup.test.js
@@ -77,43 +77,43 @@ describe('BundleGroup Tests', () => {
       assert.deepStrictEqual(eventProps, { checkpoint: 'foo' });
     });
 
-    it('creates cwv events with value properties', () => {
-      const bundle = getBundleProperties(mockRawEvent());
-      let eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 0 }), bundle);
-      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 0, timeDelta: 1 });
+    // it('creates cwv events with value properties', () => {
+    //   const bundle = getBundleProperties(mockRawEvent());
+    //   let eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 0 }), bundle);
+    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 0, timeDelta: 1 });
 
-      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 10 }), bundle);
-      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 10, timeDelta: 1 });
+    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 10 }), bundle);
+    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 10, timeDelta: 1 });
 
-      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', TTFB: 10 }), bundle);
-      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-ttfb', value: 10, timeDelta: 1 });
+    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', TTFB: 10 }), bundle);
+    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-ttfb', value: 10, timeDelta: 1 });
 
-      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', FID: 10 }), bundle);
-      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-fid', value: 10, timeDelta: 1 });
+    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', FID: 10 }), bundle);
+    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-fid', value: 10, timeDelta: 1 });
 
-      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', LCP: 10 }), bundle);
-      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-lcp', value: 10, timeDelta: 1 });
+    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', LCP: 10 }), bundle);
+    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-lcp', value: 10, timeDelta: 1 });
 
-      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', CLS: 10 }), bundle);
-      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-cls', value: 10, timeDelta: 1 });
-    });
+    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', CLS: 10 }), bundle);
+    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-cls', value: 10, timeDelta: 1 });
+    // });
 
-    it('preserves lcp source and target', () => {
-      const bundle = getBundleProperties(mockRawEvent());
-      const eventProps = getEventProperties(mockRawEvent({
-        checkpoint: 'cwv',
-        LCP: 10,
-        source: 'source',
-        target: 'target',
-      }), bundle);
-      assert.deepStrictEqual(eventProps, {
-        checkpoint: 'cwv-lcp',
-        value: 10,
-        timeDelta: 1,
-        source: 'source',
-        target: 'target',
-      });
-    });
+    // it('preserves lcp source and target', () => {
+    //   const bundle = getBundleProperties(mockRawEvent());
+    //   const eventProps = getEventProperties(mockRawEvent({
+    //     checkpoint: 'cwv',
+    //     LCP: 10,
+    //     source: 'source',
+    //     target: 'target',
+    //   }), bundle);
+    //   assert.deepStrictEqual(eventProps, {
+    //     checkpoint: 'cwv-lcp',
+    //     value: 10,
+    //     timeDelta: 1,
+    //     source: 'source',
+    //     target: 'target',
+    //   });
+    // });
 
     it('creates top level cwv events', () => {
       const bundle = getBundleProperties(mockRawEvent());

--- a/test/bundler/BundleGroup.test.js
+++ b/test/bundler/BundleGroup.test.js
@@ -77,43 +77,43 @@ describe('BundleGroup Tests', () => {
       assert.deepStrictEqual(eventProps, { checkpoint: 'foo' });
     });
 
-    // it('creates cwv events with value properties', () => {
-    //   const bundle = getBundleProperties(mockRawEvent());
-    //   let eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 0 }), bundle);
-    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 0, timeDelta: 1 });
+    it('creates cwv events with value properties', () => {
+      const bundle = getBundleProperties(mockRawEvent());
+      let eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 0 }), bundle);
+      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 0, timeDelta: 1 });
 
-    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 10 }), bundle);
-    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 10, timeDelta: 1 });
+      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', INP: 10 }), bundle);
+      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-inp', value: 10, timeDelta: 1 });
 
-    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', TTFB: 10 }), bundle);
-    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-ttfb', value: 10, timeDelta: 1 });
+      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', TTFB: 10 }), bundle);
+      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-ttfb', value: 10, timeDelta: 1 });
 
-    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', FID: 10 }), bundle);
-    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-fid', value: 10, timeDelta: 1 });
+      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', FID: 10 }), bundle);
+      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-fid', value: 10, timeDelta: 1 });
 
-    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', LCP: 10 }), bundle);
-    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-lcp', value: 10, timeDelta: 1 });
+      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', LCP: 10 }), bundle);
+      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-lcp', value: 10, timeDelta: 1 });
 
-    //   eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', CLS: 10 }), bundle);
-    //   assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-cls', value: 10, timeDelta: 1 });
-    // });
+      eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv', CLS: 10 }), bundle);
+      assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-cls', value: 10, timeDelta: 1 });
+    });
 
-    // it('preserves lcp source and target', () => {
-    //   const bundle = getBundleProperties(mockRawEvent());
-    //   const eventProps = getEventProperties(mockRawEvent({
-    //     checkpoint: 'cwv',
-    //     LCP: 10,
-    //     source: 'source',
-    //     target: 'target',
-    //   }), bundle);
-    //   assert.deepStrictEqual(eventProps, {
-    //     checkpoint: 'cwv-lcp',
-    //     value: 10,
-    //     timeDelta: 1,
-    //     source: 'source',
-    //     target: 'target',
-    //   });
-    // });
+    it('preserves lcp source and target', () => {
+      const bundle = getBundleProperties(mockRawEvent());
+      const eventProps = getEventProperties(mockRawEvent({
+        checkpoint: 'cwv',
+        LCP: 10,
+        source: 'source',
+        target: 'target',
+      }), bundle);
+      assert.deepStrictEqual(eventProps, {
+        checkpoint: 'cwv-lcp',
+        value: 10,
+        timeDelta: 1,
+        source: 'source',
+        target: 'target',
+      });
+    });
 
     it('creates top level cwv events', () => {
       const bundle = getBundleProperties(mockRawEvent());

--- a/test/bundler/BundleGroup.test.js
+++ b/test/bundler/BundleGroup.test.js
@@ -98,6 +98,23 @@ describe('BundleGroup Tests', () => {
       assert.deepStrictEqual(eventProps, { checkpoint: 'cwv-cls', value: 10, timeDelta: 1 });
     });
 
+    it('preserves lcp source and target', () => {
+      const bundle = getBundleProperties(mockRawEvent());
+      const eventProps = getEventProperties(mockRawEvent({
+        checkpoint: 'cwv',
+        LCP: 10,
+        source: 'source',
+        target: 'target',
+      }), bundle);
+      assert.deepStrictEqual(eventProps, {
+        checkpoint: 'cwv-lcp',
+        value: 10,
+        timeDelta: 1,
+        source: 'source',
+        target: 'target',
+      });
+    });
+
     it('creates top level cwv events', () => {
       const bundle = getBundleProperties(mockRawEvent());
       const eventProps = getEventProperties(mockRawEvent({ checkpoint: 'cwv' }), bundle);


### PR DESCRIPTION
Since https://github.com/adobe/helix-rum-enhancer/commit/bebb4291a1cc5fe07af31f87988c84ba07e57695, we track source and target for the LCP checkpoint. They must be preserved so that the explorer can show them. 

The code is generic and applies to other CWV which is not necessary, as of today: at one point, we might decide to track source of CLS.
