### PR TITLE
fix: save bundles in process queue

### DIFF
--- a/src/bundler/index.js
+++ b/src/bundler/index.js
@@ -227,9 +227,13 @@ export async function importEventsByKey(ctx, rawEventMap, isVirtual = false) {
     );
 
     // save touched manifests and bundles
-    await Promise.allSettled(
-      [...toSave].map((s) => s.store()),
-    );
+    await processQueue([...toSave], async (bundle) => {
+      try {
+        await bundle.store();
+      } catch (e) {
+        log.warn('failed to store bundle: ', e);
+      }
+    }, concurrency);
   }, concurrency);
 }
 

--- a/src/support/loop.js
+++ b/src/support/loop.js
@@ -91,7 +91,12 @@ export const loop = (fn, ctx, opts) => {
         stats: ctx.attributes.stats,
       }));
       if ([true, 'true'].includes(ctx.env.WRITE_PERF_LOGS)) {
-        await writeLogs(ctx, { task, measures, stats: ctx.attributes.stats });
+        await writeLogs(ctx, {
+          time: new Date().toISOString(),
+          task,
+          measures,
+          stats: ctx.attributes.stats,
+        });
       }
       performance.clearMarks();
       ctx.attributes.stats = {};


### PR DESCRIPTION
uses a processQueue instead of `Promise.allSettled()` to store the bundles.