### PR TITLE
feat(bedrock): switch from admin token to domain key authentication

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,6 +66,7 @@ jobs:
         run: npm run test-postdeploy
         env:
           HLX_TEST_HEADERS: ${{ secrets.HLX_TEST_HEADERS }}
+          TEST_DOMAINKEY_AUTH: ${{ secrets.TEST_DOMAINKEY_AUTH }}
       - name: Semantic Release (Dry Run)
         run: npm run semantic-release-dry
         env:

--- a/src/api/bedrock.js
+++ b/src/api/bedrock.js
@@ -15,7 +15,7 @@ import { STSClient, AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { BedrockRuntimeClient, InvokeModelCommand } from '@aws-sdk/client-bedrock-runtime';
 import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { LambdaClient, InvokeCommand } from '@aws-sdk/client-lambda';
-import { assertAdminOrSuperuserAuthorized } from '../support/authorization.js';
+import { assertDomainkeyAuthorized } from '../support/authorization.js';
 import { errorWithResponse } from '../support/util.js';
 import { PathInfo } from '../support/PathInfo.js';
 
@@ -106,10 +106,12 @@ async function callBedrock(client, body, log) {
  */
 async function invokeModelSync(req, ctx) {
   const { body, modelId } = validateRequest(ctx);
+  const domain = ctx.data?.domain || 'unknown';
   const region = getRegion(ctx);
   const credentials = await getCredentials(ctx, region);
   const client = new BedrockRuntimeClient({ region, credentials });
 
+  ctx.log.info(`[bedrock] sync invocation for domain=${domain}`);
   try {
     const result = await callBedrock(client, { ...body, modelId }, ctx.log);
     return new Response(JSON.stringify(result), {
@@ -206,8 +208,9 @@ async function submitJob(req, ctx) {
   const region = getRegion(ctx);
   const s3 = new S3Client({ region });
   const jobId = generateJobId();
+  const domain = ctx.data?.domain || 'unknown';
 
-  ctx.log.info(`[bedrock-job] submitting ${jobId}`);
+  ctx.log.info(`[bedrock-job] submitting ${jobId} for domain=${domain}`);
 
   // Save initial state
   await saveJob(s3, jobId, {
@@ -230,7 +233,7 @@ async function submitJob(req, ctx) {
         request: { ...body, modelId },
       }),
     }));
-    ctx.log.info(`[bedrock-job] ${jobId} async invocation triggered`);
+    ctx.log.info(`[bedrock-job] ${jobId} async invocation triggered for domain=${domain}`);
   } catch (err) {
     ctx.log.error(`[bedrock-job] ${jobId} invoke failed: ${err.message}`);
     await saveJob(s3, jobId, {
@@ -302,12 +305,12 @@ async function logUsage(req, ctx) {
     throw errorWithResponse(400, 'missing or invalid token counts');
   }
 
-  const user = ctx.attributes.adminId || 'unknown';
+  const domain = body.domain || 'unknown';
   const model = body.model || 'unknown';
   const totalTokens = body.inputTokens + body.outputTokens;
 
   ctx.log.info('[bedrock-usage]', {
-    user,
+    domain,
     model,
     inputTokens: body.inputTokens,
     outputTokens: body.outputTokens,
@@ -327,7 +330,8 @@ async function logUsage(req, ctx) {
  * @param {UniversalContext} ctx
  */
 export default async function handleRequest(req, ctx) {
-  await assertAdminOrSuperuserAuthorized(req, ctx);
+  const { domain, domainkey } = ctx.data || {};
+  await assertDomainkeyAuthorized(ctx, domain, domainkey);
 
   const info = PathInfo.fromContext(ctx);
 

--- a/src/api/bedrock.js
+++ b/src/api/bedrock.js
@@ -111,9 +111,14 @@ async function invokeModelSync(req, ctx) {
   const credentials = await getCredentials(ctx, region);
   const client = new BedrockRuntimeClient({ region, credentials });
 
+  // Strip auth fields before sending to Bedrock
+  const bedrockBody = { ...body };
+  delete bedrockBody.domain;
+  delete bedrockBody.domainkey;
+
   ctx.log.info(`[bedrock] sync invocation for domain=${domain}`);
   try {
-    const result = await callBedrock(client, { ...body, modelId }, ctx.log);
+    const result = await callBedrock(client, { ...bedrockBody, modelId }, ctx.log);
     return new Response(JSON.stringify(result), {
       status: 200,
       headers: { 'content-type': 'application/json' },
@@ -210,13 +215,18 @@ async function submitJob(req, ctx) {
   const jobId = generateJobId();
   const domain = ctx.data?.domain || 'unknown';
 
+  // Strip auth fields before storing/sending to Bedrock
+  const bedrockBody = { ...body };
+  delete bedrockBody.domain;
+  delete bedrockBody.domainkey;
+
   ctx.log.info(`[bedrock-job] submitting ${jobId} for domain=${domain}`);
 
   // Save initial state
   await saveJob(s3, jobId, {
     status: 'processing',
     createdAt: new Date().toISOString(),
-    request: { modelId, max_tokens: body.max_tokens || 4096 },
+    request: { modelId, max_tokens: bedrockBody.max_tokens || 4096 },
   });
 
   // Invoke Lambda asynchronously
@@ -230,7 +240,7 @@ async function submitJob(req, ctx) {
       Payload: JSON.stringify({
         source: 'bedrock-job',
         jobId,
-        request: { ...body, modelId },
+        request: { ...bedrockBody, modelId },
       }),
     }));
     ctx.log.info(`[bedrock-job] ${jobId} async invocation triggered for domain=${domain}`);

--- a/src/support/authorization.js
+++ b/src/support/authorization.js
@@ -12,6 +12,7 @@
 
 import { retrieveAdmin, retrieveAdminkey } from './admins.js';
 import { getDomainOrgkeyMap } from './orgs.js';
+import { fetchDomainKey } from './domains.js';
 import { HelixStorage } from './storage.js';
 import { errorWithResponse } from './util.js';
 
@@ -125,6 +126,39 @@ export async function assertAdminOrSuperuserAuthorized(req, ctx) {
   }
 
   throw errorWithResponse(403, 'invalid auth');
+}
+
+/**
+ * Asserts authorization via domainkey for a domain.
+ * Used for APIs where callers can authenticate with a valid domainkey.
+ *
+ * @param {UniversalContext} ctx
+ * @param {string} domain
+ * @param {string} domainkey
+ */
+export async function assertDomainkeyAuthorized(ctx, domain, domainkey) {
+  if (!domain || !domainkey) {
+    throw errorWithResponse(401, 'missing domain or domainkey');
+  }
+
+  // if there's an admin ident, remove it
+  let actual = domainkey;
+  const spl = actual.split('-');
+  if (spl.length === 6) {
+    actual = spl.slice(0, 5).join('-');
+  }
+
+  const expected = await fetchDomainKey(ctx, domain);
+  if (expected === null) {
+    throw errorWithResponse(401, 'domainkey not set');
+  }
+  if (expected === 'revoked') {
+    throw errorWithResponse(401, 'domainkey revoked');
+  }
+  // empty string means no auth required
+  if (expected && actual !== expected) {
+    throw errorWithResponse(403, 'invalid domainkey');
+  }
 }
 
 /**

--- a/test/api/bedrock.test.js
+++ b/test/api/bedrock.test.js
@@ -25,12 +25,12 @@ const PATH_INFO_JOBS = { suffix: '/bedrock/jobs' };
 const PATH_INFO_JOB = (id) => ({ suffix: `/bedrock/jobs/${id}` });
 const PATH_INFO_USAGE = { suffix: '/bedrock/usage' };
 
-const REQUEST = ({ method, token = 'superkey', body = null }) => new Request('https://localhost/', {
+const TEST_DOMAIN = 'example.com';
+const TEST_DOMAINKEY = 'test-domain-key';
+
+const REQUEST = ({ method, body = null }) => new Request('https://localhost/', {
   method,
-  headers: {
-    Authorization: `Bearer ${token}`,
-    'Content-Type': 'application/json',
-  },
+  headers: { 'Content-Type': 'application/json' },
   body: body ? JSON.stringify(body) : undefined,
 });
 
@@ -150,51 +150,54 @@ describe('api/bedrock Tests', function testSuite() {
   });
 
   describe('POST /bedrock (sync)', () => {
-    it('rejects missing authorization header', async () => {
-      const req = new Request('https://localhost/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ messages: [] }),
-      });
+    it('rejects missing domain or domainkey', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
+      const req = REQUEST({ method: 'POST', body: { messages: [] } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_SYNC,
-        env: { TMP_SUPERUSER_API_KEY: 'superkey' },
-      });
-      await assertRejectsWithResponse(() => handleRequest(req, ctx), 401, 'missing auth');
-    });
-
-    it('rejects invalid token', async () => {
-      const req = REQUEST({ method: 'POST', token: 'bad', body: { messages: [] } });
-      const ctx = DEFAULT_CONTEXT({
-        pathInfo: PATH_INFO_SYNC,
-        env: { TMP_SUPERUSER_API_KEY: 'superkey' },
         data: { messages: [] },
       });
-      await assertRejectsWithResponse(() => handleRequest(req, ctx), 403, 'invalid auth');
+      await assertRejectsWithResponse(() => handleRequest(req, ctx), 401, 'missing domain or domainkey');
+    });
+
+    it('rejects invalid domainkey', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
+      const req = REQUEST({ method: 'POST', body: { messages: [] } });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_SYNC,
+        data: { messages: [], domain: TEST_DOMAIN, domainkey: 'wrong-key' },
+      });
+      await assertRejectsWithResponse(() => handleRequest(req, ctx), 403, 'invalid domainkey');
     });
 
     it('rejects missing messages', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: {} });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_SYNC, data: {} });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_SYNC,
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 400, 'missing messages in request body');
     });
 
     it('rejects missing modelId', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_SYNC,
         env: { BEDROCK_MODEL_ID: undefined },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 400, 'missing modelId in request body or environment');
     });
 
     it('returns 200 with response on success', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_SYNC,
         env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 200);
@@ -203,35 +206,38 @@ describe('api/bedrock Tests', function testSuite() {
     });
 
     it('returns 502 on bedrock error', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       bedrockError = new Error('Model error');
       bedrockError.name = 'ModelError';
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_SYNC,
         env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 502, 'bedrock error: ModelError');
     });
 
     it('returns 502 on STS error', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       stsError = new Error('STS failed');
       stsError.name = 'STSError';
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_SYNC,
         env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID, BEDROCK_ROLE_ARN: 'arn:aws:iam::123:role/test' },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 502, 'sts error: STSError');
     });
 
     it('uses STS credentials when BEDROCK_ROLE_ARN is set', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_SYNC,
         env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID, BEDROCK_ROLE_ARN: 'arn:aws:iam::123:role/test' },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 200);
@@ -240,17 +246,22 @@ describe('api/bedrock Tests', function testSuite() {
 
   describe('POST /bedrock/jobs (async)', () => {
     it('rejects missing messages', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: {} });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOBS, data: {} });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOBS,
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 400, 'missing messages in request body');
     });
 
     it('returns 202 with jobId on success', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_JOBS,
         env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID, AWS_LAMBDA_FUNCTION_NAME: 'test' },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 202);
@@ -260,11 +271,12 @@ describe('api/bedrock Tests', function testSuite() {
     });
 
     it('saves job to S3 and invokes Lambda', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_JOBS,
         env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID, AWS_LAMBDA_FUNCTION_NAME: 'test' },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       const resp = await handleRequest(req, ctx);
       const { jobId } = await resp.json();
@@ -279,13 +291,14 @@ describe('api/bedrock Tests', function testSuite() {
     });
 
     it('returns 502 and saves failed status on Lambda invoke error', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       lambdaError = new Error('Lambda invoke failed');
       lambdaError.name = 'ServiceException';
       const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_JOBS,
         env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID, AWS_LAMBDA_FUNCTION_NAME: 'test' },
-        data: { messages: MESSAGES },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 502, 'failed to start job');
 
@@ -300,16 +313,24 @@ describe('api/bedrock Tests', function testSuite() {
 
   describe('GET /bedrock/jobs/{jobId}', () => {
     it('returns 404 for non-existent job', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'GET' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOB('job_none'), env: {} });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOB('job_none'),
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 404, 'job not found');
     });
 
     it('returns processing job', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const jobId = 'job_test1';
       s3Storage[`bedrock-jobs/${jobId}.json`] = JSON.stringify({ status: 'processing' });
       const req = REQUEST({ method: 'GET' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOB(jobId), env: {} });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOB(jobId),
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 200);
       const body = await resp.json();
@@ -317,13 +338,17 @@ describe('api/bedrock Tests', function testSuite() {
     });
 
     it('returns completed job with result', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const jobId = 'job_test2';
       s3Storage[`bedrock-jobs/${jobId}.json`] = JSON.stringify({
         status: 'completed',
         result: MOCK_BEDROCK_RESPONSE,
       });
       const req = REQUEST({ method: 'GET' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOB(jobId), env: {} });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOB(jobId),
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       const resp = await handleRequest(req, ctx);
       const body = await resp.json();
       assert.strictEqual(body.status, 'completed');
@@ -331,13 +356,17 @@ describe('api/bedrock Tests', function testSuite() {
     });
 
     it('returns failed job with error', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const jobId = 'job_test3';
       s3Storage[`bedrock-jobs/${jobId}.json`] = JSON.stringify({
         status: 'failed',
         error: { name: 'Err', message: 'fail' },
       });
       const req = REQUEST({ method: 'GET' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOB(jobId), env: {} });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOB(jobId),
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       const resp = await handleRequest(req, ctx);
       const body = await resp.json();
       assert.strictEqual(body.status, 'failed');
@@ -345,10 +374,14 @@ describe('api/bedrock Tests', function testSuite() {
     });
 
     it('throws on S3 error other than NoSuchKey', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       s3Error = new Error('Access Denied');
       s3Error.name = 'AccessDenied';
       const req = REQUEST({ method: 'GET' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOB('job_err'), env: {} });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOB('job_err'),
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       await assert.rejects(
         () => handleRequest(req, ctx),
         (err) => err.name === 'AccessDenied',
@@ -383,24 +416,32 @@ describe('api/bedrock Tests', function testSuite() {
 
   describe('POST /bedrock/usage', () => {
     it('rejects missing reportId', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { inputTokens: 100, outputTokens: 50 } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_USAGE,
-        data: { inputTokens: 100, outputTokens: 50 },
+        data: {
+          inputTokens: 100,
+          outputTokens: 50,
+          domain: TEST_DOMAIN,
+          domainkey: TEST_DOMAINKEY,
+        },
       });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 400, 'missing reportId');
     });
 
     it('rejects missing token counts', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { reportId: 'report_123' } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_USAGE,
-        data: { reportId: 'report_123' },
+        data: { reportId: 'report_123', domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
       });
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 400, 'missing or invalid token counts');
     });
 
     it('logs usage via log.info and returns 200', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: {} });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_USAGE,
@@ -409,8 +450,9 @@ describe('api/bedrock Tests', function testSuite() {
           model: 'claude-opus-4-6',
           inputTokens: 45000,
           outputTokens: 12000,
+          domain: TEST_DOMAIN,
+          domainkey: TEST_DOMAINKEY,
         },
-        attributes: { adminId: 'alice' },
       });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 200);
@@ -421,7 +463,7 @@ describe('api/bedrock Tests', function testSuite() {
       const infoCalls = ctx.log.calls.info;
       const usageLog = infoCalls.find((call) => call[0] === '[bedrock-usage]');
       assert.ok(usageLog, 'should log usage');
-      assert.strictEqual(usageLog[1].user, 'alice');
+      assert.strictEqual(usageLog[1].domain, TEST_DOMAIN);
       assert.strictEqual(usageLog[1].model, 'claude-opus-4-6');
       assert.strictEqual(usageLog[1].inputTokens, 45000);
       assert.strictEqual(usageLog[1].outputTokens, 12000);
@@ -429,7 +471,8 @@ describe('api/bedrock Tests', function testSuite() {
       assert.strictEqual(usageLog[1].reportId, 'report_abc123');
     });
 
-    it('uses unknown for missing admin ID and model', async () => {
+    it('uses unknown for missing domain and model', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: {} });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_USAGE,
@@ -437,8 +480,9 @@ describe('api/bedrock Tests', function testSuite() {
           reportId: 'report_anon',
           inputTokens: 100,
           outputTokens: 50,
+          domain: TEST_DOMAIN,
+          domainkey: TEST_DOMAINKEY,
         },
-        attributes: {},
       });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 200);
@@ -446,29 +490,41 @@ describe('api/bedrock Tests', function testSuite() {
       const infoCalls = ctx.log.calls.info;
       const usageLog = infoCalls.find((call) => call[0] === '[bedrock-usage]');
       assert.ok(usageLog, 'should log usage');
-      assert.strictEqual(usageLog[1].user, 'unknown');
+      assert.strictEqual(usageLog[1].domain, TEST_DOMAIN);
       assert.strictEqual(usageLog[1].model, 'unknown');
     });
   });
 
   describe('HTTP method handling', () => {
     it('rejects GET on /bedrock', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'GET' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_SYNC });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_SYNC,
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 405);
     });
 
     it('rejects PUT on /bedrock/jobs', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'PUT' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOBS });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOBS,
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 405);
     });
 
     it('rejects POST on /bedrock/jobs/{jobId}', async () => {
+      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST' });
-      const ctx = DEFAULT_CONTEXT({ pathInfo: PATH_INFO_JOB('x') });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_JOB('x'),
+        data: { domain: TEST_DOMAIN, domainkey: TEST_DOMAINKEY },
+      });
       const resp = await handleRequest(req, ctx);
       assert.strictEqual(resp.status, 405);
     });

--- a/test/api/bedrock.test.js
+++ b/test/api/bedrock.test.js
@@ -169,6 +169,39 @@ describe('api/bedrock Tests', function testSuite() {
       await assertRejectsWithResponse(() => handleRequest(req, ctx), 403, 'invalid domainkey');
     });
 
+    it('rejects when domainkey not set', async () => {
+      nock.domainKey(TEST_DOMAIN, null);
+      const req = REQUEST({ method: 'POST', body: { messages: [] } });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_SYNC,
+        data: { messages: [], domain: TEST_DOMAIN, domainkey: 'any-key' },
+      });
+      await assertRejectsWithResponse(() => handleRequest(req, ctx), 401, 'domainkey not set');
+    });
+
+    it('rejects revoked domainkey', async () => {
+      nock.domainKey(TEST_DOMAIN, 'revoked');
+      const req = REQUEST({ method: 'POST', body: { messages: [] } });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_SYNC,
+        data: { messages: [], domain: TEST_DOMAIN, domainkey: 'any-key' },
+      });
+      await assertRejectsWithResponse(() => handleRequest(req, ctx), 401, 'domainkey revoked');
+    });
+
+    it('strips admin ident suffix from domainkey', async () => {
+      const fivePartKey = 'abcd-efgh-ijkl-mnop-qrst';
+      nock.domainKey(TEST_DOMAIN, fivePartKey);
+      const req = REQUEST({ method: 'POST', body: { messages: MESSAGES } });
+      const ctx = DEFAULT_CONTEXT({
+        pathInfo: PATH_INFO_SYNC,
+        env: { BEDROCK_MODEL_ID: OPUS_MODEL_ID },
+        data: { messages: MESSAGES, domain: TEST_DOMAIN, domainkey: `${fivePartKey}-admin` },
+      });
+      const resp = await handleRequest(req, ctx);
+      assert.strictEqual(resp.status, 200);
+    });
+
     it('rejects missing messages', async () => {
       nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: {} });

--- a/test/api/bedrock.test.js
+++ b/test/api/bedrock.test.js
@@ -151,7 +151,6 @@ describe('api/bedrock Tests', function testSuite() {
 
   describe('POST /bedrock (sync)', () => {
     it('rejects missing domain or domainkey', async () => {
-      nock.domainKey(TEST_DOMAIN, TEST_DOMAINKEY);
       const req = REQUEST({ method: 'POST', body: { messages: [] } });
       const ctx = DEFAULT_CONTEXT({
         pathInfo: PATH_INFO_SYNC,

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -18,9 +18,12 @@ const OPUS_MODEL_ID = 'us.anthropic.claude-opus-4-6-v1';
 const POLL_INTERVAL = 3000;
 const MAX_POLL_TIME = 180000; // 3 minutes max for polling
 
-// Domain key auth for bedrock tests
-const { TEST_DOMAINKEY } = process.env;
-const TEST_DOMAIN = process.env.TEST_DOMAIN || 'www.thinktanked.org';
+// Domain key auth for bedrock tests (parsed from JSON secret)
+const domainkeyAuth = process.env.TEST_DOMAINKEY_AUTH
+  ? JSON.parse(process.env.TEST_DOMAINKEY_AUTH)
+  : {};
+const TEST_DOMAIN = domainkeyAuth.domain || 'thinktanked.org';
+const TEST_DOMAINKEY = domainkeyAuth.domainkey;
 
 /**
  * Poll job status until complete or timeout

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -38,6 +38,7 @@ async function pollJobUntilComplete(fetch, url, headers, jobId) {
     // eslint-disable-next-line no-await-in-loop
     const res = await fetch(jobUrl, {
       method: 'GET',
+      headers,
     });
 
     if (!res.ok) {
@@ -109,7 +110,7 @@ createTargets().forEach((target) => {
     it('calls bedrock sync API for quick request', async () => {
       const res = await fetch(target.url('/bedrock'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...target.headers, 'Content-Type': 'application/json' },
         body: JSON.stringify({
           domain: TEST_DOMAIN,
           domainkey: TEST_DOMAINKEY,
@@ -140,7 +141,7 @@ createTargets().forEach((target) => {
     it('submits async job and returns jobId', async () => {
       const res = await fetch(target.url('/bedrock/jobs'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...target.headers, 'Content-Type': 'application/json' },
         body: JSON.stringify({
           domain: TEST_DOMAIN,
           domainkey: TEST_DOMAINKEY,
@@ -162,7 +163,7 @@ createTargets().forEach((target) => {
       // Submit job
       const submitRes = await fetch(target.url('/bedrock/jobs'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...target.headers, 'Content-Type': 'application/json' },
         body: JSON.stringify({
           domain: TEST_DOMAIN,
           domainkey: TEST_DOMAINKEY,
@@ -194,7 +195,7 @@ createTargets().forEach((target) => {
       // Submit large request as async job
       const submitRes = await fetch(target.url('/bedrock/jobs'), {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { ...target.headers, 'Content-Type': 'application/json' },
         body: JSON.stringify({
           domain: TEST_DOMAIN,
           domainkey: TEST_DOMAINKEY,
@@ -233,6 +234,7 @@ Include sections on performance metrics and traffic patterns.`,
       const jobUrl = `${target.url('/bedrock/jobs/job_nonexistent_12345')}?domain=${encodeURIComponent(TEST_DOMAIN)}&domainkey=${encodeURIComponent(TEST_DOMAINKEY)}`;
       const res = await fetch(jobUrl, {
         method: 'GET',
+        headers: target.headers,
       });
       assert.strictEqual(res.status, 404);
     }).timeout(30000);

--- a/test/post-deploy.test.js
+++ b/test/post-deploy.test.js
@@ -18,11 +18,15 @@ const OPUS_MODEL_ID = 'us.anthropic.claude-opus-4-6-v1';
 const POLL_INTERVAL = 3000;
 const MAX_POLL_TIME = 180000; // 3 minutes max for polling
 
+// Domain key auth for bedrock tests
+const { TEST_DOMAINKEY } = process.env;
+const TEST_DOMAIN = process.env.TEST_DOMAIN || 'www.thinktanked.org';
+
 /**
  * Poll job status until complete or timeout
  */
 async function pollJobUntilComplete(fetch, url, headers, jobId) {
-  const jobUrl = `${url}/bedrock/jobs/${jobId}`;
+  const jobUrl = `${url}/bedrock/jobs/${jobId}?domain=${encodeURIComponent(TEST_DOMAIN)}&domainkey=${encodeURIComponent(TEST_DOMAINKEY)}`;
   const startTime = Date.now();
 
   while (Date.now() - startTime < MAX_POLL_TIME) {
@@ -34,7 +38,6 @@ async function pollJobUntilComplete(fetch, url, headers, jobId) {
     // eslint-disable-next-line no-await-in-loop
     const res = await fetch(jobUrl, {
       method: 'GET',
-      headers,
     });
 
     if (!res.ok) {
@@ -106,8 +109,10 @@ createTargets().forEach((target) => {
     it('calls bedrock sync API for quick request', async () => {
       const res = await fetch(target.url('/bedrock'), {
         method: 'POST',
-        headers: { ...target.headers, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          domain: TEST_DOMAIN,
+          domainkey: TEST_DOMAINKEY,
           modelId: OPUS_MODEL_ID,
           messages: [{ role: 'user', content: 'Say OK' }],
           max_tokens: 10,
@@ -135,8 +140,10 @@ createTargets().forEach((target) => {
     it('submits async job and returns jobId', async () => {
       const res = await fetch(target.url('/bedrock/jobs'), {
         method: 'POST',
-        headers: { ...target.headers, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          domain: TEST_DOMAIN,
+          domainkey: TEST_DOMAINKEY,
           modelId: OPUS_MODEL_ID,
           messages: [{ role: 'user', content: 'Say hello' }],
           max_tokens: 50,
@@ -155,8 +162,10 @@ createTargets().forEach((target) => {
       // Submit job
       const submitRes = await fetch(target.url('/bedrock/jobs'), {
         method: 'POST',
-        headers: { ...target.headers, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          domain: TEST_DOMAIN,
+          domainkey: TEST_DOMAINKEY,
           modelId: OPUS_MODEL_ID,
           messages: [{ role: 'user', content: 'Say hello in exactly 5 words' }],
           max_tokens: 50,
@@ -185,8 +194,10 @@ createTargets().forEach((target) => {
       // Submit large request as async job
       const submitRes = await fetch(target.url('/bedrock/jobs'), {
         method: 'POST',
-        headers: { ...target.headers, 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          domain: TEST_DOMAIN,
+          domainkey: TEST_DOMAINKEY,
           modelId: OPUS_MODEL_ID,
           messages: [{
             role: 'user',
@@ -219,9 +230,9 @@ Include sections on performance metrics and traffic patterns.`,
     }).timeout(240000);
 
     it('returns 404 for non-existent job', async () => {
-      const res = await fetch(target.url('/bedrock/jobs/job_nonexistent_12345'), {
+      const jobUrl = `${target.url('/bedrock/jobs/job_nonexistent_12345')}?domain=${encodeURIComponent(TEST_DOMAIN)}&domainkey=${encodeURIComponent(TEST_DOMAINKEY)}`;
+      const res = await fetch(jobUrl, {
         method: 'GET',
-        headers: target.headers,
       });
       assert.strictEqual(res.status, 404);
     }).timeout(30000);


### PR DESCRIPTION
## Summary
- Replace `assertAdminOrSuperuserAuthorized` with `assertDomainkeyAuthorized` for bedrock API endpoints
- Callers now authenticate with `domain` + `domainkey` params in the request body instead of bearer tokens
- Enables OpTel dashboard users to access bedrock AI features without requiring admin privileges

## Test plan
- [ ] Verify domain key validation works for valid keys
- [ ] Verify invalid domain keys are rejected with 403
- [ ] Verify missing domain or domainkey returns 401
- [ ] Verify revoked domain keys are handled correctly
- [ ] Test async job submission with domain key auth
- [ ] Test usage logging includes domain instead of user

🤖 Generated with [Claude Code](https://claude.com/claude-code)