### PR TITLE
fix: bundle events from chrome-extension:// URLs

### DIFF
--- a/src/bundler/index.js
+++ b/src/bundler/index.js
@@ -325,7 +325,11 @@ export function sortRawEvents(rawEvents, log) {
     }
 
     try {
-      if (!url.hostname.includes('.') && url.hostname !== 'localhost') {
+      if (
+        !url.hostname.includes('.')
+        && url.hostname !== 'localhost'
+        && url.protocol !== 'chrome-extension:'
+      ) {
         log.info('ignoring event with invalid url (no tld): ', event.url, event.id);
         return;
       }

--- a/test/bundler/index.test.js
+++ b/test/bundler/index.test.js
@@ -153,6 +153,38 @@ describe('bundler Tests', () => {
       });
     });
 
+    it('allows chrome-extension urls', () => {
+      const sorted = sortRawEvents([{
+        url: 'chrome-extension://akjjllgokmbgpbdbmafpiefnhidlmbgf/index.html',
+        id: 'a',
+        time: 0,
+      }], log);
+      assert.deepStrictEqual(sorted, {
+        domains: [
+          'akjjllgokmbgpbdbmafpiefnhidlmbgf',
+        ],
+        rawEventMap: {
+          '/akjjllgokmbgpbdbmafpiefnhidlmbgf/1970/1/1/0.json': {
+            events: [
+              {
+                id: 'a',
+                time: 0,
+                url: 'chrome-extension://akjjllgokmbgpbdbmafpiefnhidlmbgf/index.html',
+              },
+            ],
+            info: {
+              day: 1,
+              domain: 'akjjllgokmbgpbdbmafpiefnhidlmbgf',
+              hour: 0,
+              month: 1,
+              year: 1970,
+            },
+          },
+        },
+        virtualMap: {},
+      });
+    });
+
     it('ignores urls with relative hosts', () => {
       const sorted = sortRawEvents([{ url: 'https://..' }], log);
       assert.deepStrictEqual(sorted, { rawEventMap: {}, domains: [], virtualMap: {} });


### PR DESCRIPTION
## Summary
The no-TLD guard in `sortRawEvents` (`src/bundler/index.js:328`) discards every event whose URL hostname lacks a dot, with an explicit carve-out only for `localhost`. Chrome extensions report under `chrome-extension://<id>/...`, where `new URL(...).hostname` is the bare 32-char extension ID — no dot, not localhost — so the bundling pipeline drops them.

The collector's BigQuery write path (`google-logger.mjs:70-75`) has no equivalent guard, which is why these events show up in `helix_rum.cluster` but never appear in `/bundles/{ext-id}/Y/M/D` results.

## Change
- Allow events through the bundler when `url.protocol === 'chrome-extension:'`, matching the localhost carve-out.
- Add a `sortRawEvents` test using a real-world extension ID to lock in the behavior.

## How it changes existing code
- One line: a third clause is added to the existing guard. Behavior for all currently-supported URL shapes is unchanged; only previously-rejected `chrome-extension:` events now pass through to the rawEventMap and the domains set, using the bare extension ID as the storage key (consistent with `location.hostname`).

## Breaks
- None. The check this loosens currently rejects with a log line and a return; nothing depends on it.

## Test plan
- [x] `sortRawEvents` unit tests still pass (10 cases including the new one)
- [x] Full `npm test` suite passes (181 tests)
- [x] `npm run lint` shows no new issues (the one pre-existing error in `test/dev/tools/import-domainkeys-to-bq.js` is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)