### PR TITLE
fix(ci): add TEST_DOMAINKEY_AUTH to release job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -109,3 +109,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HLX_TEST_HEADERS: ${{ secrets.HLX_TEST_HEADERS }}
+          TEST_DOMAINKEY_AUTH: ${{ secrets.TEST_DOMAINKEY_AUTH }}


### PR DESCRIPTION
## Summary
- Add `TEST_DOMAINKEY_AUTH` env var to the release job
- The secret was only passed to `test-deploy` but not to `release`, causing post-deploy tests to fail on main branch merges

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Merge and confirm release completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)